### PR TITLE
fix: 修复因免打扰按钮导致的通知面板误触问题

### DIFF
--- a/entrypoints/components/BasicSettings/MenuDonotTopic.vue
+++ b/entrypoints/components/BasicSettings/MenuDonotTopic.vue
@@ -21,7 +21,8 @@ export default {
   emits: ["update:modelValue"],
   data() {
     return {
-      donotTopicIntervalId: null // 添加变量存储定时器ID
+      observer: null,
+      eventHandlersAttached: false, // Flag to ensure handlers are attached only once
     };
   },
   methods: {
@@ -35,7 +36,7 @@ export default {
         messageElement.remove();
       }, 3000);
     },
-    init() {
+    addButtons() {
       if (window.location.href != "https://linux.do/latest?state=muted") {
         $(".topic-list .main-link a.title").each(function () {
           const id = $(this).attr("data-topic-id");
@@ -61,18 +62,22 @@ export default {
           }
         });
       }
+    },
+    // This function attaches the event handlers
+    attachEventHandlers() {
+        if(this.eventHandlersAttached) return; // Don't attach more than once
 
-      function getCSRFToken() {
-        return document.querySelector('meta[name="csrf-token"]').getAttribute("content");
-      }
-      let vm = this;
-      // 点击免打扰
-      $(document)
-        .off("click", ".donottopic-btn")
-        .on("click", ".donottopic-btn", function () {
-          const formData = new FormData();
-          formData.append("notification_level", 0);
-          const topicId = $(this).attr("data-id");
+        function getCSRFToken() {
+            return document.querySelector('meta[name="csrf-token"]').getAttribute("content");
+        }
+        let vm = this;
+
+        // Using event delegation on document, so it only needs to be attached once.
+        // Click "Do Not Disturb"
+        $(document).on("click", ".donottopic-btn", function () {
+            const formData = new FormData();
+            formData.append("notification_level", 0);
+            const topicId = $(this).attr("data-id");
 
           return new Promise((resolve, reject) => {
             // 发送带有 CSRF Token 的 POST 请求
@@ -102,13 +107,11 @@ export default {
           });
         });
 
-      // 点击移出免打扰
-      $(document)
-        .off("click", ".removedonottopic-btn")
-        .on("click", ".removedonottopic-btn", function () {
-          const formData = new FormData();
-          formData.append("notification_level", 1);
-          const topicId = $(this).attr("data-id");
+        // Click "Remove from Do Not Disturb"
+        $(document).on("click", ".removedonottopic-btn", function () {
+            const formData = new FormData();
+            formData.append("notification_level", 1);
+            const topicId = $(this).attr("data-id");
 
           return new Promise((resolve, reject) => {
             // 发送带有 CSRF Token 的 POST 请求
@@ -137,27 +140,45 @@ export default {
               });
           });
         });
-    },
+
+        this.eventHandlersAttached = true; // Set flag
+    }
   },
   created() {
     if (this.modelValue) {
-      this.donotTopicIntervalId = setInterval(() => {
-        this.init();
-      }, 1000);
+      // Attach event handlers ONCE
+      this.attachEventHandlers();
+
+      // Run button adder once initially
+      this.addButtons();
+
+      // Set up observer to run button adder on DOM changes
+      this.observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          if (mutation.addedNodes.length) {
+            this.addButtons();
+            // We only need to find new nodes, so we can break after finding them.
+            break;
+          }
+        }
+      });
+
+      const targetNode = document.querySelector('body');
+      const config = { childList: true, subtree: true };
+      this.observer.observe(targetNode, config);
     }
   },
   beforeUnmount() {
-    // 清除定时器
-    if (this.donotTopicIntervalId) {
-      clearInterval(this.donotTopicIntervalId);
+    if (this.observer) {
+      this.observer.disconnect();
     }
+    // Note: Delegated event handlers on `document` are not removed,
+    // which is generally fine for a content script that lives with the page.
+    // If this component could be mounted/unmounted multiple times,
+    // we would need to add logic to remove them (`$(document).off(...)`).
   },
-  // Vue 2 兼容性
   beforeDestroy() {
-    // 清除定时器
-    if (this.donotTopicIntervalId) {
-      clearInterval(this.donotTopicIntervalId);
-    }
+    this.beforeUnmount();
   }
 };
 </script>


### PR DESCRIPTION
本 PR 旨在解决 issue #155 中报告的问题，即“列表快速免打扰帖子”功能会与原生通知面板产生冲突，导致用户在关闭通知面板后，点击页面任何区域都会再次触发它。

  问题的根本原因是 MenuDonotTopic.vue 组件中的 setInterval 导致全局点击事件被反复、不必要地注册，从而干扰了页面的正常事件流。

  此次重构通过以下方式解决了该问题：
  - 用 MutationObserver 替代 setInterval：更高效、精准地监听新话题的出现，并动态添加“免打扰”按钮。
  - 确保事件只绑定一次：重构了事件处理逻辑，确保利用事件委托绑定的 click 事件在组件的整个生命周期中只会被注册一次。

  这些改动彻底消除了事件冲突，并优化了性能。

  测试计划

  1. 在扩展设置中，启用 通用设置 -> 外置按钮 -> “列表快速免打扰帖子” 功能。
  2. 刷新页面，并浏览任何帖子列表页面（如首页或分类页）。
  3. 将鼠标悬浮在任意帖子上，确认“免打扰”按钮正常出现。
  4. 点击右上角的个人头像，正常打开通知面板。
  5. 关闭通知面板。
  6. 点击页面的任何空白区域或进行其他交互。

  预期结果:
  - 通知面板不会再被意外触发。
  - “免打扰”功能本身（点击按钮将帖子设为免打扰）可以正常工作。
