### PR TITLE
feat: 重新实现智能链接跳转功能（之前的代码被覆盖了，上个合并是空的）

### DIFF
--- a/entrypoints/DialogComponents/components/NewsPosts.vue
+++ b/entrypoints/DialogComponents/components/NewsPosts.vue
@@ -15,8 +15,7 @@
         </button>
         <a
           :href="'https://linux.do/t/topic/' + item.id"
-          target="_blank"
-          @click="handleLinkClick(item.id)"
+          @click="handleLinkClick($event, item.id)"
           class="news-link"
           :ref="`link-${item.id}`"
           @mouseenter="showTooltip($event, item.title)"
@@ -54,10 +53,44 @@ export default {
     }
   },
   methods: {
-    handleLinkClick(itemId) {
-      // 点击链接时，向父组件发送移除事件
+    async handleLinkClick(event, itemId) {
+      // 阻止默认的链接行为
+      event.preventDefault();
+
+      // 构建目标URL
+      const targetUrl = `https://linux.do/t/topic/${itemId}`;
+
+      try {
+        const browserAPI = typeof browser !== "undefined" ? browser : chrome;
+
+        // 查询当前活动的标签页
+        const tabs = await new Promise((resolve) => {
+          browserAPI.tabs.query({ active: true, currentWindow: true }, resolve);
+        });
+
+        if (tabs.length > 0) {
+          const currentTab = tabs[0];
+
+          // 检查当前活动标签页是否为 linux.do
+          if (currentTab.url && currentTab.url.includes('linux.do')) {
+            // 如果当前标签页是 linux.do，直接在当前标签页跳转
+            browserAPI.tabs.update(currentTab.id, { url: targetUrl });
+          } else {
+            // 如果不是 linux.do，创建新标签页
+            browserAPI.tabs.create({ url: targetUrl });
+          }
+        } else {
+          // 如果无法获取标签页信息，默认创建新标签页
+          browserAPI.tabs.create({ url: targetUrl });
+        }
+      } catch (error) {
+        console.error('处理链接跳转失败：', error);
+        // 出错时回退到新标签页打开
+        window.open(targetUrl, '_blank');
+      }
+
+      // 向父组件发送移除事件
       this.$emit("remove-item", itemId);
-      // 链接的默认行为（跳转）会正常执行
     },
 
     previewPost(itemId) {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     name: 'LinuxDo Scripts',
     version: pkg.version,
     description: '为 linux.do 用户提供了一些增强功能。',
-    permissions: ['storage', 'sidePanel'],
+    permissions: ['storage', 'sidePanel', 'tabs'],
     host_permissions: ['http://*/*', 'https://*/*'],
     side_panel: {
       default_path: 'sidepanel.html'


### PR DESCRIPTION
- 检测当前活动标签页是否为linux.do域名
- 在linux.do内点击帖子链接时直接在当前页面跳转
- 在其他网站点击时新开标签页打开
- 使用浏览器扩展tabs API实现标签页操作
- 添加tabs权限支持到manifest配置
- 包含完整的错误处理和回退机制
- 优化用户浏览体验，避免产生过多标签页
- 修复之前提交中丢失的智能跳转代码