### PR TITLE
fix: 修复点击搜索结果无法在新标签页打开的问题

### DIFF
--- a/entrypoints/SettingComponents/BasicSettings/MenuOpenpostblank.vue
+++ b/entrypoints/SettingComponents/BasicSettings/MenuOpenpostblank.vue
@@ -12,7 +12,7 @@ export default {
   created() {
       if (this.modelValue) {
         function handleLinkClick(e) {
-          const linkSelector='.link-top-line a.title, .search-results a.search-link, .search-result-topic a.search-link'
+          const linkSelector='.link-top-line a.raw-link, .search-results a.search-link, .search-result-topic a.search-link'
           // 检查被点击的元素或其父元素是否是要找的<a>标签
           const link = e.target.closest(linkSelector);
           

--- a/entrypoints/SettingComponents/BasicSettings/MenuOpenpostblank.vue
+++ b/entrypoints/SettingComponents/BasicSettings/MenuOpenpostblank.vue
@@ -10,58 +10,26 @@ export default {
   props: ["modelValue", "sort"],
   emits: ["update:modelValue"],
   created() {
-    if (this.modelValue) {
-
-      // 处理链接点击
-      function handleLinkClick(e) {
-        e.preventDefault();
-        e.stopPropagation(); // 阻止事件冒泡
-        e.stopImmediatePropagation(); // 阻止事件捕获和后续相同事件的处理
-        window.open(this.href, '_blank', 'noopener,noreferrer');
-      }
-
-      // 主要功能
-      function processLinks() {
-        // 查找所有帖子标题链接，扩展选择器以包含搜索页面的链接
-        const links = document.querySelectorAll('.link-top-line a.title:not([data-processed])');
-
-        links.forEach(link => {
-          // 标记该链接已处理
-          link.setAttribute('data-processed', 'true');
-          // 添加事件监听器
-          link.addEventListener('click', handleLinkClick);
-        });
-      }
-
-      // 监听 DOM 变化，处理动态加载的内容
-      const observer = new MutationObserver((mutations) => {
-        const hasNewLinks = mutations.some(mutation => {
-          return Array.from(mutation.addedNodes).some(node => {
-            return node.nodeType === 1 && (
-              node.classList.contains('link-top-line') ||
-              node.querySelector('.link-top-line') ||
-              node.classList.contains('search-results') ||
-              node.querySelector('.search-results')
-            );
-          });
-        });
-
-        if (hasNewLinks) {
-          processLinks();
+      if (this.modelValue) {
+        function handleLinkClick(e) {
+          const linkSelector='.link-top-line a.title, .search-results a.search-link, .search-result-topic a.search-link'
+          // 检查被点击的元素或其父元素是否是要找的<a>标签
+          const link = e.target.closest(linkSelector);
+          
+          if (link && link.href) {
+            e.preventDefault();
+            e.stopPropagation();
+            e.stopImmediatePropagation();
+            
+            window.open(link.href, '_blank', 'noopener,noreferrer');
+          }
         }
-      });
-
-      // 开始观察
-      observer.observe(document.body, {
-        childList: true,
-        subtree: true
-      });
-
-      // 初始处理
-      processLinks();
-
-    }
-  },
+        
+        // 使用事件委托，在 body 上监听一次即可，无需 MutationObserver
+        // 使用 { capture: true } 在捕获阶段拦截事件，确保最高优先级
+        document.body.addEventListener('click', handleLinkClick, { capture: true });
+      }
+    },
 
 };
 </script>


### PR DESCRIPTION
之前有人提了修复 https://github.com/anghunk/linuxdo-scripts/pull/194 。但是最新版本没把这个修复 https://github.com/anghunk/linuxdo-scripts/pull/194 合并进去。

之前的 PR [#194](https://github.com/anghunk/linuxdo-scripts/pull/194) 注意到了这个问题并尝试修复，但其实现方式引入了一个新的 Bug：当用户点击搜索结果时，链接不仅会在新标签页打开，同时也会在原始标签页加载，导致一次点击触发两次页面跳转。

问题复现：
<img width="711" height="408" alt="image" src="https://github.com/user-attachments/assets/338412d3-0674-44fc-8631-459084fe0bef" />

点击搜索结果后，原始标签页也打开了帖子
<img width="687" height="186" alt="image" src="https://github.com/user-attachments/assets/5e7991f3-64e9-46a5-91a7-28a2bc3ab9fa" />


问题修复：
- 确保首页和搜索的链接在新标签页中打开。
- 修复一次点击导致两个标签页都打开的 Bug。

测试系统：Win11

测试浏览器：Edge,Chrome和Firefox，都为最新版本。

解决方案
```javascript
  created() {
      if (this.modelValue) {
        function handleLinkClick(e) {
          const linkSelector='.link-top-line a.raw-link, .search-results a.search-link, .search-result-topic a.search-link'
          // 检查被点击的元素或其父元素是否是要找的<a>标签
          const link = e.target.closest(linkSelector);
          
          if (link && link.href) {
            e.preventDefault();
            e.stopPropagation();
            e.stopImmediatePropagation();
            
            window.open(link.href, '_blank', 'noopener,noreferrer');
          }
        }
        
        // 使用事件委托，在 body 上监听一次即可，无需 MutationObserver
        // 使用 { capture: true } 在捕获阶段拦截事件，确保最高优先级
        document.body.addEventListener('click', handleLinkClick, { capture: true });
      }
    },
```



