### PR TITLE
fix: sanitize AI markdown rendering

### DIFF
--- a/entrypoints/SettingComponents/AIConfig/GPTconfig.vue
+++ b/entrypoints/SettingComponents/AIConfig/GPTconfig.vue
@@ -156,6 +156,7 @@
 
 <script>
 import $ from 'jquery';
+import DOMPurify from 'dompurify';
 import { marked } from 'marked';
 import storageCompat, { getSafeSettings } from '../../utilities/storageCompat.js';
 import dbStorage from '../../utilities/indexedDBStorage.js';
@@ -208,6 +209,10 @@ export default {
 		},
 	},
 	methods: {
+		renderSafeMarkdown(markdown) {
+			const html = marked.parse(markdown || '');
+			return DOMPurify.sanitize(html);
+		},
 		handleKeyDown(e) {
 			if (e.altKey && e.key === '-') {
 				e.preventDefault();
@@ -528,7 +533,7 @@ export default {
 								if (cachedContent) {
 									$('.post-stream').before(
 										`<div class="gpt-summary-wrap">
-<div class="gpt-summary">${marked.parse(cachedContent)}</div>
+<div class="gpt-summary">${this.renderSafeMarkdown(cachedContent)}</div>
 </div>`,
 									);
 								}
@@ -659,7 +664,7 @@ export default {
 									if (jsonData.choices?.[0]?.delta?.content) {
 										const content = jsonData.choices[0].delta.content;
 										fullContent += content;
-										$('.gpt-summary').html(marked.parse(fullContent));
+										$('.gpt-summary').html(this.renderSafeMarkdown(fullContent));
 									}
 								} catch (error) {
 									// 忽略解析错误
@@ -677,7 +682,7 @@ export default {
 						resolve();
 					} else if (message.action === 'ai_stream_error') {
 						browserAPI.runtime.onMessage.removeListener(streamListener);
-						$('.gpt-summary').html(`生成失败：${message.error}`);
+						$('.gpt-summary').text(`生成失败：${message.error}`);
 						reject(new Error(message.error));
 					}
 				};
@@ -697,14 +702,14 @@ export default {
 					(response) => {
 						if (browserAPI.runtime.lastError) {
 							browserAPI.runtime.onMessage.removeListener(streamListener);
-							$('.gpt-summary').html(`生成失败：${browserAPI.runtime.lastError.message}`);
+							$('.gpt-summary').text(`生成失败：${browserAPI.runtime.lastError.message}`);
 							reject(new Error(browserAPI.runtime.lastError.message));
 							return;
 						}
 
 						if (!response?.started) {
 							browserAPI.runtime.onMessage.removeListener(streamListener);
-							$('.gpt-summary').html(`生成失败：无法启动流式请求`);
+							$('.gpt-summary').text(`生成失败：无法启动流式请求`);
 							reject(new Error('无法启动流式请求'));
 						}
 					},
@@ -715,7 +720,7 @@ export default {
 		// 生成 AI 回复（通过 background script 绕过 CORS）
 		async setAIRelpy() {
 			$('.aireply-popup').show();
-			$('.aireply-popup-text').html('AI 推荐回复正在生成中，请稍后。。。');
+			$('.aireply-popup-text').text('AI 推荐回复正在生成中，请稍后。。。');
 			const settingsData = getSafeSettings();
 			const config = settingsData ? settingsData.gptdata : this.localChecked;
 			const browserAPI = typeof browser !== 'undefined' ? browser : chrome;
@@ -765,7 +770,7 @@ ${str}`;
 					},
 					(response) => {
 						if (browserAPI.runtime.lastError) {
-							$('.aireply-popup-text').html(`生成失败：${browserAPI.runtime.lastError.message}`);
+							$('.aireply-popup-text').text(`生成失败：${browserAPI.runtime.lastError.message}`);
 							reject(new Error(browserAPI.runtime.lastError.message));
 							return;
 						}
@@ -777,7 +782,7 @@ ${str}`;
 							resolve();
 						} else {
 							const errorMsg = response.data?.error?.message || response.error || '未知错误';
-							$('.aireply-popup-text').html(`生成失败：${errorMsg}`);
+							$('.aireply-popup-text').text(`生成失败：${errorMsg}`);
 							reject(new Error(errorMsg));
 						}
 					},
@@ -864,7 +869,7 @@ ${str}`;
 
 		// 推荐回复弹窗
 		AIReplyPopup(text) {
-			$('.aireply-popup-text').html(text);
+			$('.aireply-popup-text').text(text);
 		},
 		// AI 根据新建话题内容生成标题（通过 background script 绕过 CORS）
 		async getCreateNewTopicTitle() {
@@ -958,7 +963,7 @@ ${topic_contentdata}`;
 						if (cachedContent) {
 							$('.post-stream').before(
 								`<div class="gpt-summary-wrap">
-<div class="gpt-summary">${marked.parse(cachedContent)}</div>
+<div class="gpt-summary">${this.renderSafeMarkdown(cachedContent)}</div>
 </div>`,
 							);
 						} else if (!this.localChecked.btn) {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@arco-themes/vue-indigo-sky": "^0.0.1",
+    "dompurify": "^3.4.5",
     "html2canvas": "^1.4.1",
     "jquery": "^3.7.1",
     "marked": "^14.1.1",


### PR DESCRIPTION

This PR fixes an XSS risk in AI summary rendering by sanitizing Markdown-rendered HTML before inserting it into the page DOM.
本 PR 修复 AI 总结渲染中的 XSS 风险：在将 Markdown 渲染结果插入页面 DOM 前，先使用 DOMPurify 进行 HTML 安全过滤。

## Changes

  - Add `dompurify` as a runtime dependency.
  新增运行时依赖 `dompurify`

  - Add a `renderSafeMarkdown()` helper for AI summary rendering.
  新增 `renderSafeMarkdown()`，统一处理 AI 总结的 Markdown 安全渲染

  - Replace direct `marked.parse(...)` DOM insertion with sanitized output.
  将直接插入 `marked.parse(...)` 输出的逻辑改为插入已清洗后的 HTML

  - Change AI/API error and reply text output from `.html(...)` to `.text(...)`.
  将 AI/API 错误信息和 AI 回复内容从 `.html(...)` 改为 `.text(...)` 输出，避免不可信内容被当作 HTML 执行。

## Screenshots
<img width="269" height="99" alt="XSS-bug" src="https://github.com/user-attachments/assets/e383025e-7fcd-463b-b37c-9b0843022203" />

### fixed
<img width="366" height="483" alt="XSS-bug-FIXED" src="https://github.com/user-attachments/assets/d8e3f3ee-8d3b-4153-b9bf-5f801475e936" />

<img width="264" height="97" alt="XSS-bug-FIXED1" src="https://github.com/user-attachments/assets/60c2aff1-b4b2-450b-b7fa-b55433d315cf" />


